### PR TITLE
Bug fix: Fix total read pages count.

### DIFF
--- a/apps/server/src/books/books-service.ts
+++ b/apps/server/src/books/books-service.ts
@@ -34,8 +34,15 @@ export class BooksService {
   }
 
   static getTotalReadPages(book: Book, stats: PageStat[]): number {
+    const seen_pages = new Set<number>();
     return Math.round(
       stats.reduce((acc, stat) => {
+        if (seen_pages.has(stat.page)) {
+          return acc;
+        }
+
+        seen_pages.add(stat.page);
+
         if (book.reference_pages) {
           return acc + (1 / stat.total_pages) * book.reference_pages;
         } else {


### PR DESCRIPTION
This change means that we only count the unique pages towards total pages read of book.

I've left other places that use the same `PageStat` data type alone (arguably if you read the same page 5 times, it should count as reading 5 pages in most stats....but it shouldn't contribute 5 pages read towards a specific book).

Before change:

<img width="692" alt="image" src="https://github.com/user-attachments/assets/773cdaee-fbe1-496b-9e72-ba178d954aab" />

After change:

<img width="673" alt="image" src="https://github.com/user-attachments/assets/3fc09da3-fdd2-45dc-be4d-5d71617ee70d" />


(Different covers between my actual instance and dev machine unrelated....)