### PR TITLE
feat(plugin): register sync action for availability in gestures

### DIFF
--- a/plugins/koinsight.koplugin/main.lua
+++ b/plugins/koinsight.koplugin/main.lua
@@ -15,6 +15,7 @@ local koinsight = WidgetContainer:extend{
 }
 
 function koinsight:init()
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     self.koinsight_settings = KoInsightSettings:new{}
 end
@@ -48,6 +49,23 @@ function koinsight:addToMainMenu(menu_items)
             end
         }}
     }
+end
+
+-- Register sync action to make it available in gestures
+function koinsight:onDispatcherRegisterActions()
+    Dispatcher:registerAction(
+        "koinsight_sync",
+        {
+            category = "network",
+            event    = "KoInsightSync",
+            title    = _("KoInsight: Sync stats"),
+            general  = true
+        }
+    )
+end
+
+function koinsight:onKoInsightSync()
+    onUpload(self.koinsight_settings.server_url)
 end
 
 return koinsight

--- a/plugins/koinsight.koplugin/main.lua
+++ b/plugins/koinsight.koplugin/main.lua
@@ -56,7 +56,7 @@ function koinsight:onDispatcherRegisterActions()
     Dispatcher:registerAction(
         "koinsight_sync",
         {
-            category = "network",
+            category = "none",
             event    = "KoInsightSync",
             title    = _("KoInsight: Sync stats"),
             general  = true


### PR DESCRIPTION
This registers the KoInsight sync data as an action so it can be used in gestures, for example in tap-corner menus and such.