### PR TITLE
Add auto-connect functionality when syncing

### DIFF
--- a/plugins/koinsight.koplugin/main.lua
+++ b/plugins/koinsight.koplugin/main.lua
@@ -8,6 +8,7 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local KoInsightSettings = require("settings")
 local KoInsightDbReader = require("db_reader")
 local JSON = require("json")
+local NetworkMgr = require("ui/network/manager")
 
 local koinsight = WidgetContainer:extend({
   name = "koinsight",
@@ -38,7 +39,9 @@ function koinsight:addToMainMenu(menu_items)
         text = _("Synchronize data"),
         separator = true,
         callback = function()
-          onUpload(self.koinsight_settings.server_url)
+          NetworkMgr:runWhenOnline(function()
+            onUpload(self.koinsight_settings.server_url)
+          end)
         end,
       },
       {
@@ -68,7 +71,9 @@ function koinsight:onDispatcherRegisterActions()
 end
 
 function koinsight:onKoInsightSync()
-  onUpload(self.koinsight_settings.server_url)
+  NetworkMgr:runWhenOnline(function()
+    onUpload(self.koinsight_settings.server_url)
+  end)
 end
 
 function koinsight:initMenuOrder()


### PR DESCRIPTION
I added minimal changes so when I press the Sync stats menu item or call the sync action via gestures it auto-connects to wifi if not already connected.

So you don't have to connect manually and then sync.

I figured it was possible because Wallabag2 plugin does it, and I think it makes sense as syncing is only possible when connected. Hope you find it useful