### PR TITLE
Added rounding to 2 decimal places for progress percentage

### DIFF
--- a/apps/web/src/pages/syncs-page.tsx
+++ b/apps/web/src/pages/syncs-page.tsx
@@ -99,8 +99,8 @@ export function SyncsPage() {
                         <Tooltip withArrow label="Percentage">
                           <IconPercentage size={18} />
                         </Tooltip>
-                        <Progress w="100" value={(Math.round(progress.percentage * 10000)/100).toFixed(2)} />{' '}
-                        {(Math.round(progress.percentage * 10000)/100).toFixed(2)}%
+                        <Progress w="100" value={(progress.percentage * 100.toFixed(2)} />{' '}
+                        {((progress.percentage * 100).toFixed(2)}%
                       </Flex>
                     </Flex>
                   </Card>


### PR DESCRIPTION
Hi, 

Previously the progress percentage parameter on the progress syncs page was showing a lot of trailing decimals. This is just a quick change to round that number down to 2 decimals. 

Thanks, 
Harseerat