### PR TITLE
Added rounding to progress percentage on progress sync page

### DIFF
--- a/apps/web/src/pages/syncs-page.tsx
+++ b/apps/web/src/pages/syncs-page.tsx
@@ -99,8 +99,8 @@ export function SyncsPage() {
                         <Tooltip withArrow label="Percentage">
                           <IconPercentage size={18} />
                         </Tooltip>
-                        <Progress w="100" value={progress.percentage * 100} />{' '}
-                        {progress.percentage * 100}%
+                        <Progress w="100" value={(progress.percentage * 100).toFixed(2)} />{' '}
+                        {(progress.percentage * 100).toFixed(2)}%
                       </Flex>
                     </Flex>
                   </Card>


### PR DESCRIPTION
### Example of difference below:

<img width="1137" height="434" alt="500297887-6b391a46-ef67-4edc-b873-4c7ecf17028d" src="https://github.com/user-attachments/assets/6b357719-d815-4d38-8439-69658a687df3" />
<img width="1137" height="434" alt="500297890-e42ba954-db9b-4621-bb1b-f9feaf2aae7c" src="https://github.com/user-attachments/assets/1e41c73c-e535-4aa1-9325-6df47b1ddf15" />
