### PR TITLE
Fix: unify Zod version across workspaces + migrate OpenAI API to resp…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": ">=22"
   },
+  "resolutions": {
+    "zod": "3.23.8"
+  },
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -6,5 +6,11 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch"
-  }
+  },
+  "peerDependencies": {
+   "zod": "^3.23.0"
+  },
+  "devDependencies": {
+   "zod": "^3.23.0"
+ }
 }


### PR DESCRIPTION
This PR fixes the build failure caused by two issues:

1. **Deprecated OpenAI API**
   The code used `beta.chat.completions.parse`, which no longer exists in the current OpenAI SDK.
   Updated to the new `responses.parse` API, including the required input/message structure.

2. **Zod version mismatch across workspaces**
   Several packages used different Zod versions, causing TS type incompatibilities during `tsc -b`.
   - Added a single Zod version via `resolutions` in the root package.json
   - Converted workspace Zod usage to `peerDependencies` + `devDependencies` for proper deduplication

### Result
- `tsc -b` runs cleanly
- Docker build succeeds
- OpenAI functionality is now aligned with the latest SDK
- No unrelated files were modified