### PR TITLE
feat: add a button that directly syncs db from webdav

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -30,6 +30,7 @@
     "openai": "6.5.0",
     "ramda": "0.31.1",
     "sqlite3": "^5.1.7",
+    "webdav": "^5.8.0",
     "zod": "4.1.12"
   },
   "devDependencies": {

--- a/apps/web/src/components/navbar/navbar.tsx
+++ b/apps/web/src/components/navbar/navbar.tsx
@@ -14,6 +14,7 @@ import {
   IconMoon,
   IconReload,
   IconSun,
+  IconCloud,
 } from '@tabler/icons-react';
 import { JSX, useState } from 'react';
 import { NavLink, useLocation } from 'react-router';
@@ -23,6 +24,7 @@ import { DownloadPluginModal } from './download-plugin';
 import { UploadForm } from './upload-form';
 
 import style from './navbar.module.css';
+import { WebDavSyncButton } from '../upload/web-dav-sync-button';
 
 export function Navbar({ onNavigate }: { onNavigate?: () => void }): JSX.Element {
   const { pathname } = useLocation();
@@ -84,6 +86,7 @@ export function Navbar({ onNavigate }: { onNavigate?: () => void }): JSX.Element
       <div className={style.Footer}>
         <Flex gap="xs">
           <UploadForm />
+          <WebDavSyncButton />
           <ActionIcon
             onClick={toggleColorScheme}
             variant="default"

--- a/apps/web/src/components/upload/web-dav-connect.tsx
+++ b/apps/web/src/components/upload/web-dav-connect.tsx
@@ -1,0 +1,109 @@
+import { FormEvent, useEffect, useState } from 'react';
+import {
+  ActionIcon,
+  Button,
+  Group,
+  Modal,
+  PasswordInput,
+  Stack,
+  TextInput,
+  Tooltip,
+} from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { IconCloud, IconInfoCircle} from '@tabler/icons-react';
+
+type WebDavConnectModalProps = {
+  opened: boolean;
+  onClose: () => void;
+  loading: boolean;
+  initialConfig?: WebdavConfig | null;
+  onSubmit: (config: WebdavConfig) => void;
+};
+
+export type WebdavConfig = {
+  url: string;
+  folder: string;
+  username?: string;
+  password?: string;
+};
+
+export function WebDavConnectModal({ opened, onClose, loading, initialConfig, onSubmit}: WebDavConnectModalProps) {
+  const [url, setUrl] = useState('');
+  const [folder, setFolder] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  useEffect(() => {
+    if (opened) {
+      setUrl(initialConfig?.url ?? '');
+      setFolder(initialConfig?.folder ?? '');
+      setUsername(initialConfig?.username ?? '');
+      setPassword(initialConfig?.password ?? '');
+    }
+  }, [opened, initialConfig]);
+
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      url: url.trim(),
+      folder: folder.trim(),
+      username: username.trim() || undefined,
+      password: password || undefined,
+    });
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title="Sync from WebDAV"
+      centered
+    >
+      <form onSubmit={handleSubmit}>
+        <Stack>
+          <TextInput
+            label="WebDAV Address"
+            placeholder="https://example.com/dav"
+            value={url}
+            onChange={(e) => setUrl(e.currentTarget.value)}
+            required
+          />
+          <TextInput
+            label={
+              <Group gap={4}>
+                Remote Folder
+                <Tooltip label="The remote folder that holds the database.">
+                  <ActionIcon variant="subtle" size="sm" color="gray">
+                    <IconInfoCircle size={14} />
+                  </ActionIcon>
+                </Tooltip>
+              </Group>
+            }
+            placeholder="koreader_statistics"
+            value={folder}
+            onChange={(e) => setFolder(e.currentTarget.value)}
+          />
+          <TextInput
+            label="Username"
+            value={username}
+            onChange={(e) => setUsername(e.currentTarget.value)}
+          />
+          <PasswordInput
+            label="Password"
+            value={password}
+            onChange={(e) => setPassword(e.currentTarget.value)}
+          />
+          <Group justify="flex-end" mt="md">
+            <Button variant="default" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={loading}>
+              Connect
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/upload/web-dav-sync-button.tsx
+++ b/apps/web/src/components/upload/web-dav-sync-button.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { ActionIcon } from '@mantine/core';
+import { showNotification } from '@mantine/notifications';
+import { IconCloud } from '@tabler/icons-react';
+import { WebDavConnectModal, WebdavConfig } from './web-dav-connect';
+
+export function WebDavSyncButton() {
+  const [config, setConfig] = useState<WebdavConfig | null>(null);
+  const [modalOpened, setModalOpened] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const syncWithConfig = async (cfg: WebdavConfig) => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/upload/from-webdav', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(cfg),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(text || `Request failed with status ${res.status}`);
+      }
+
+      showNotification({
+        title: 'Successfully Synced',
+        message: 'Successfully imported database from WebDAV.',
+        icon: <IconCloud size={18} />,
+        color: 'green',
+      });
+    } catch (err: any) {
+      showNotification({
+        title: 'Sync Failed',
+        message:
+          err?.message ??
+          'Failed to connect to WebDAV server or import database.',
+        color: 'red',
+      });
+
+      setModalOpened(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClick = () => {
+    if (!config) {
+      setModalOpened(true);
+    } else {
+      void syncWithConfig(config);
+    }
+  };
+
+  const handleModalSubmit = (cfg: WebdavConfig) => {
+    setConfig(cfg);
+    setModalOpened(false);
+    void syncWithConfig(cfg);
+  };
+
+  return (
+    <>
+      <ActionIcon
+          variant="default"
+          size="lg"
+          aria-label="WebDAV"
+          loading={loading}
+          onClick={handleClick}
+        >
+          <IconCloud stroke={1.5} />
+      </ActionIcon>
+
+      <WebDavConnectModal
+        opened={modalOpened}
+        onClose={() => setModalOpened(false)}
+        loading={loading}
+        initialConfig={config}
+        onSubmit={handleModalSubmit}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Since KOReader already supports syncing reading statistics via WebDAV, I add this button to provide a more convenient way for syncing. Users who have configured WebDAV sync can manually trigger a database synchronization when needed.

A new button has been added to the footbar.
<img width="600" alt="Add New Button" src="https://github.com/user-attachments/assets/b243216b-1a34-49d2-99d5-ae36d5f1a758" />

On first use, or if a sync attempt fails, the user will be prompted to configure their WebDAV login information.
<img width="400" alt="ScreenShot_2025-11-30_182810_223" src="https://github.com/user-attachments/assets/979bdc9a-4a67-4c5b-ab74-bc5723298378" />



