### PR TITLE
fix: annotations marked as deleted (fixes #86)

### DIFF
--- a/apps/server/src/annotations/annotations-repository.ts
+++ b/apps/server/src/annotations/annotations-repository.ts
@@ -75,7 +75,16 @@ export class AnnotationsRepository {
           .onConflict(['book_md5', 'device_id', 'page_ref', 'datetime'])
           // Only update fields that users can actually change in KoReader
           // Do NOT update pageno/total_pages - these are historical context!
-          .merge(['text', 'note', 'datetime_updated', 'chapter', 'updated_at', 'drawer', 'color']);
+          .merge([
+            'text',
+            'note',
+            'datetime_updated',
+            'chapter',
+            'updated_at',
+            'drawer',
+            'color',
+            'deleted_at',
+          ]);
       }
     };
 

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -123,16 +123,10 @@ export class UploadService {
           )
         );
 
-        const bookMd5s = newBooks.map((b) => b.md5).filter((md5): md5 is string => !!md5);
-
+        // FIXME: with this, if there is only 1 annotation and it gets removed, it won't get marked as deleted, because `annotationsByBook` will be empty. It will only get marked as deleted if the user adds another annotation to trigger an update on the book.
         await Promise.all(
-          bookMd5s.map((bookMd5) =>
-            this.detectAndMarkDeletedAnnotations(
-              bookMd5,
-              deviceId,
-              annotationsByBook[bookMd5] || [],
-              trx
-            )
+          Object.entries(annotationsByBook).map(([bookMd5, annotations]) =>
+            this.detectAndMarkDeletedAnnotations(bookMd5, deviceId, annotations, trx)
           )
         );
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "build": "turbo run build",
-    "test:coverage": "turbo run test:coverage"
+    "test:coverage": "turbo run test:coverage",
+    "dev": "turbo run dev --parallel"
   },
   "devDependencies": {
     "prettier": "3.6.2",


### PR DESCRIPTION
Reverts the change from #82 and fixes #86.

This brings back the old bug of deleting the last annotation of a book, but it is way more acceptable.

It also allows annotations to be "restored" - if an annotation conflicts it means it is present in the book, and the `deleted_at` field will get reset.

