### PR TITLE
Harden sync

### DIFF
--- a/apps/server/src/books/books-service.test.ts
+++ b/apps/server/src/books/books-service.test.ts
@@ -72,6 +72,13 @@ describe(BooksService.withData, () => {
 
       expect(result.started_reading).toEqual(1720898518000);
     });
+
+    it('returns 0 if no stats are available', async () => {
+      const book1 = await createBook(db, { title: 'Test Book 1' });
+      const result = await BooksService.withData(book1);
+
+      expect(result.started_reading).toEqual(0);
+    });
   });
 
   describe('read_per_day', () => {

--- a/apps/server/src/books/books-service.ts
+++ b/apps/server/src/books/books-service.ts
@@ -16,6 +16,7 @@ export class BooksService {
   }
 
   static getStartedReading(stats: PageStat[]): number {
+    if (stats.length === 0) return 0;
     return stats.reduce((acc, stat) => Math.min(acc, stat.start_time), Infinity);
   }
 

--- a/apps/server/src/upload/upload-service-annotations.test.ts
+++ b/apps/server/src/upload/upload-service-annotations.test.ts
@@ -1,8 +1,9 @@
-import { KoReaderAnnotation } from '@koinsight/common/types';
+import { KoReaderAnnotation, KoReaderBook, PageStat } from '@koinsight/common/types';
 import { createBook } from '../db/factories/book-factory';
 import { createDevice } from '../db/factories/device-factory';
 import { db } from '../knex';
 import { AnnotationsRepository } from '../annotations/annotations-repository';
+import { UploadService } from './upload-service';
 
 describe('UploadService with annotations', () => {
   describe('annotation data structure from KoReader', () => {
@@ -57,14 +58,14 @@ describe('UploadService with annotations', () => {
       expect(counts.bookmark).toBe(1);
 
       // Verify annotation content
-      const highlight = importedAnnotations.find(a => a.annotation_type === 'highlight');
+      const highlight = importedAnnotations.find((a) => a.annotation_type === 'highlight');
       expect(highlight?.text).toBe('First highlight from KoReader');
       expect(highlight?.color).toBe('yellow');
 
-      const note = importedAnnotations.find(a => a.annotation_type === 'note');
+      const note = importedAnnotations.find((a) => a.annotation_type === 'note');
       expect(note?.note).toBe('This is important!');
 
-      const bookmark = importedAnnotations.find(a => a.annotation_type === 'bookmark');
+      const bookmark = importedAnnotations.find((a) => a.annotation_type === 'bookmark');
       expect(bookmark?.pageno).toBe(50);
     });
 
@@ -117,5 +118,99 @@ describe('UploadService with annotations', () => {
       expect(annotations[0].text).toBe('Updated text'); // Text was updated
       expect(annotations[0].datetime_updated).toBe('2024-01-16T10:00:00');
     });
+  });
+});
+
+describe('UploadService page stat input hardening', () => {
+  const makeBook = (md5: string): KoReaderBook => ({
+    id: 1,
+    md5,
+    title: 'Test Book',
+    authors: 'Author',
+    series: '',
+    language: 'en',
+    notes: 0,
+    highlights: 0,
+    last_open: 0,
+    pages: 100,
+    total_read_time: 0,
+    total_read_pages: 0,
+  });
+
+  it('succeeds when stats is a non-array object (annotation-only path)', async () => {
+    const book = await createBook(db, { md5: 'hardening-test-1' });
+
+    await expect(
+      UploadService.uploadStatisticData([makeBook(book.md5)], {} as unknown as PageStat[])
+    ).resolves.not.toThrow();
+
+    const rows = await db('page_stat').where({ book_md5: book.md5 });
+    expect(rows).toHaveLength(0);
+  });
+
+  it('drops null/undefined/non-object entries in stats array', async () => {
+    const book = await createBook(db, { md5: 'hardening-test-2' });
+    const device = await createDevice(db);
+
+    const statsWithJunk = [
+      null,
+      undefined,
+      'not-an-object',
+      42,
+      {
+        device_id: device.id,
+        book_md5: book.md5,
+        page: 1,
+        start_time: 1000,
+        duration: 10,
+        total_pages: 100,
+      },
+    ] as unknown as PageStat[];
+
+    await expect(
+      UploadService.uploadStatisticData([makeBook(book.md5)], statsWithJunk)
+    ).resolves.not.toThrow();
+
+    const rows = await db('page_stat').where({ book_md5: book.md5 });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('drops stats with zero or invalid duration/total_pages', async () => {
+    const book = await createBook(db, { md5: 'hardening-test-3' });
+    const device = await createDevice(db);
+
+    const invalidStats: PageStat[] = [
+      {
+        device_id: device.id,
+        book_md5: book.md5,
+        page: 1,
+        start_time: 1000,
+        duration: 0,
+        total_pages: 100,
+      },
+      {
+        device_id: device.id,
+        book_md5: book.md5,
+        page: 2,
+        start_time: 1001,
+        duration: 10,
+        total_pages: 0,
+      },
+      {
+        device_id: device.id,
+        book_md5: book.md5,
+        page: 3,
+        start_time: 1002,
+        duration: -1,
+        total_pages: 100,
+      },
+    ];
+
+    await expect(
+      UploadService.uploadStatisticData([makeBook(book.md5)], invalidStats)
+    ).resolves.not.toThrow();
+
+    const rows = await db('page_stat').where({ book_md5: book.md5 });
+    expect(rows).toHaveLength(0);
   });
 });

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -128,11 +128,11 @@ export class UploadService {
       // Insert page stats (only on stats sync path! there are none for annotation sync path)
       const validPageStats = safePageStats.filter(
         (s) =>
-          s.duration != null &&
+          s != null &&
+          typeof s === 'object' &&
           typeof s.duration === 'number' &&
           Number.isFinite(s.duration) &&
           s.duration > 0 &&
-          s.total_pages != null &&
           typeof s.total_pages === 'number' &&
           Number.isFinite(s.total_pages) &&
           s.total_pages > 0

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -63,10 +63,10 @@ export class UploadService {
       );
 
       // Determine device ID: from stats, override, or fall back to unknown device
-      const deviceId =
-        safePageStats.length > 0
-          ? safePageStats[0].device_id
-          : deviceIdOverride || this.UNKNOWN_DEVICE_ID;
+      const firstValidStat = safePageStats.find(
+        (s) => s != null && typeof s === 'object' && typeof s.device_id === 'string'
+      );
+      const deviceId = firstValidStat?.device_id ?? deviceIdOverride ?? this.UNKNOWN_DEVICE_ID;
 
       const hasUnknownDevices = deviceId === this.UNKNOWN_DEVICE_ID;
 

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -125,7 +125,7 @@ export class UploadService {
         })
       );
 
-      // Insert page stats (only on stats sync path! there are non for annotation sync path)
+      // Insert page stats (only on stats sync path! there are none for annotation sync path)
       const validPageStats = safePageStats.filter(
         (s) =>
           s.duration != null &&

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -52,10 +52,8 @@ export class UploadService {
         (s) =>
           s != null &&
           typeof s === 'object' &&
-          typeof s.duration === 'number' &&
           Number.isFinite(s.duration) &&
           s.duration > 0 &&
-          typeof s.total_pages === 'number' &&
           Number.isFinite(s.total_pages) &&
           s.total_pages > 0
       );
@@ -74,7 +72,7 @@ export class UploadService {
       );
 
       // Determine device ID: from stats, override, or fall back to unknown device
-      const firstValidStat = safePageStats.find((s) => typeof s.device_id === 'string');
+      const firstValidStat = safePageStats.find((s) => s.device_id);
       const deviceId = firstValidStat?.device_id ?? deviceIdOverride ?? this.UNKNOWN_DEVICE_ID;
 
       const hasUnknownDevices = deviceId === this.UNKNOWN_DEVICE_ID;
@@ -114,7 +112,7 @@ export class UploadService {
 
           // Only merge last_open if it's a valid positive Unix timestamp (seconds)
           const last_open = bookDevice.last_open;
-          if (typeof last_open === 'number' && Number.isFinite(last_open) && last_open > 0) {
+          if (Number.isFinite(last_open) && last_open > 0) {
             fieldsToMerge.push('last_open');
           }
 

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -46,8 +46,19 @@ export class UploadService {
   ) {
     return db.transaction(async (trx) => {
       // Normalize: the plugin sends {} (empty Lua table → JSON object) on the
-      // annotation-only path, not []. Guard all array operations against this.
-      const safePageStats = Array.isArray(newPageStats) ? newPageStats : [];
+      // annotation-only path, not []. Guard all array operations against this,
+      // and drop clearly invalid page stat rows.
+      const safePageStats = (Array.isArray(newPageStats) ? newPageStats : []).filter(
+        (s) =>
+          s != null &&
+          typeof s === 'object' &&
+          typeof s.duration === 'number' &&
+          Number.isFinite(s.duration) &&
+          s.duration > 0 &&
+          typeof s.total_pages === 'number' &&
+          Number.isFinite(s.total_pages) &&
+          s.total_pages > 0
+      );
       // Insert books
       const newBooks: Partial<Book>[] = booksToImport.map((book) => ({
         id: book.id,
@@ -63,9 +74,7 @@ export class UploadService {
       );
 
       // Determine device ID: from stats, override, or fall back to unknown device
-      const firstValidStat = safePageStats.find(
-        (s) => s != null && typeof s === 'object' && typeof s.device_id === 'string'
-      );
+      const firstValidStat = safePageStats.find((s) => typeof s.device_id === 'string');
       const deviceId = firstValidStat?.device_id ?? deviceIdOverride ?? this.UNKNOWN_DEVICE_ID;
 
       const hasUnknownDevices = deviceId === this.UNKNOWN_DEVICE_ID;
@@ -126,20 +135,9 @@ export class UploadService {
       );
 
       // Insert page stats (only on stats sync path! there are none for annotation sync path)
-      const validPageStats = safePageStats.filter(
-        (s) =>
-          s != null &&
-          typeof s === 'object' &&
-          typeof s.duration === 'number' &&
-          Number.isFinite(s.duration) &&
-          s.duration > 0 &&
-          typeof s.total_pages === 'number' &&
-          Number.isFinite(s.total_pages) &&
-          s.total_pages > 0
-      );
-      if (validPageStats.length > 0) {
+      if (safePageStats.length > 0) {
         await Promise.all(
-          validPageStats.map((pageStat) =>
+          safePageStats.map((pageStat) =>
             trx<PageStat>('page_stat')
               .insert(pageStat)
               .onConflict(['device_id', 'book_md5', 'page', 'start_time'])

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -45,6 +45,9 @@ export class UploadService {
     deviceIdOverride?: string // For annotation sync path without stats
   ) {
     return db.transaction(async (trx) => {
+      // Normalize: the plugin sends {} (empty Lua table → JSON object) on the
+      // annotation-only path, not []. Guard all array operations against this.
+      const safePageStats = Array.isArray(newPageStats) ? newPageStats : [];
       // Insert books
       const newBooks: Partial<Book>[] = booksToImport.map((book) => ({
         id: book.id,
@@ -61,8 +64,8 @@ export class UploadService {
 
       // Determine device ID: from stats, override, or fall back to unknown device
       const deviceId =
-        newPageStats.length > 0
-          ? newPageStats[0].device_id
+        safePageStats.length > 0
+          ? safePageStats[0].device_id
           : deviceIdOverride || this.UNKNOWN_DEVICE_ID;
 
       const hasUnknownDevices = deviceId === this.UNKNOWN_DEVICE_ID;
@@ -123,7 +126,7 @@ export class UploadService {
       );
 
       // Insert page stats (only on stats sync path! there are non for annotation sync path)
-      const validPageStats = newPageStats.filter(
+      const validPageStats = safePageStats.filter(
         (s) =>
           s.duration != null &&
           typeof s.duration === 'number' &&

--- a/apps/server/src/upload/upload-service.ts
+++ b/apps/server/src/upload/upload-service.ts
@@ -97,8 +97,14 @@ export class UploadService {
           const { book_md5, device_id, total_read_time, total_read_pages, ...otherFields } =
             bookDevice;
 
-          // Always merge these fields
-          const fieldsToMerge: (keyof BookDevice)[] = ['last_open', 'pages', 'notes', 'highlights'];
+          // Always merge these fields (last_open added conditionally below)
+          const fieldsToMerge: (keyof BookDevice)[] = ['pages', 'notes', 'highlights'];
+
+          // Only merge last_open if it's a valid positive Unix timestamp (seconds)
+          const last_open = bookDevice.last_open;
+          if (typeof last_open === 'number' && Number.isFinite(last_open) && last_open > 0) {
+            fieldsToMerge.push('last_open');
+          }
 
           // Only merge statistics fields if they have actual values (if on statistics.db sync path)
           // This prevents annotation-only syncs from overwriting with zeros
@@ -117,9 +123,20 @@ export class UploadService {
       );
 
       // Insert page stats (only on stats sync path! there are non for annotation sync path)
-      if (newPageStats.length > 0) {
+      const validPageStats = newPageStats.filter(
+        (s) =>
+          s.duration != null &&
+          typeof s.duration === 'number' &&
+          Number.isFinite(s.duration) &&
+          s.duration > 0 &&
+          s.total_pages != null &&
+          typeof s.total_pages === 'number' &&
+          Number.isFinite(s.total_pages) &&
+          s.total_pages > 0
+      );
+      if (validPageStats.length > 0) {
         await Promise.all(
-          newPageStats.map((pageStat) =>
+          validPageStats.map((pageStat) =>
             trx<PageStat>('page_stat')
               .insert(pageStat)
               .onConflict(['device_id', 'book_md5', 'page', 'start_time'])

--- a/apps/web/src/pages/book-page/book-page.tsx
+++ b/apps/web/src/pages/book-page/book-page.tsx
@@ -157,7 +157,8 @@ function StatsCard({ book }: { book: BookWithData }): JSX.Element {
     book?.device_data.reduce((acc, device) => Math.max(acc, device.pages), 0) ||
     0;
 
-  const avgPerDay = book ? book.total_read_time / Object.keys(book.read_per_day).length : 0;
+  const readingDays = book ? Object.keys(book.read_per_day).length : 0;
+  const avgPerDay = readingDays > 0 ? book!.total_read_time / readingDays : 0;
 
   return (
     <Paper

--- a/apps/web/src/pages/book-page/book-page.tsx
+++ b/apps/web/src/pages/book-page/book-page.tsx
@@ -158,7 +158,7 @@ function StatsCard({ book }: { book: BookWithData }): JSX.Element {
     0;
 
   const readingDays = book ? Object.keys(book.read_per_day).length : 0;
-  const avgPerDay = readingDays > 0 ? book!.total_read_time / readingDays : 0;
+  const avgPerDay = readingDays > 0 ? (book?.total_read_time ?? 0) / readingDays : 0;
 
   return (
     <Paper

--- a/plugins/koinsight.koplugin/annotation_reader.lua
+++ b/plugins/koinsight.koplugin/annotation_reader.lua
@@ -216,7 +216,7 @@ function KoInsightAnnotationReader.getBookDataFromSidecar(file_path)
     pages = total_pages or 0,
     highlights = (stats and stats.highlights) or 0,
     notes = (stats and stats.notes) or 0,
-    last_open = (summary and summary.modified) or os.time(),
+    last_open = os.time(),
   }
 
   return md5, annotations, total_pages, book_metadata

--- a/plugins/koinsight.koplugin/annotation_reader.lua
+++ b/plugins/koinsight.koplugin/annotation_reader.lua
@@ -204,7 +204,6 @@ function KoInsightAnnotationReader.getBookDataFromSidecar(file_path)
   -- Extract book metadata from sidecar
   local doc_props = doc_settings:readSetting("doc_props")
   local stats = doc_settings:readSetting("stats")
-  local summary = doc_settings:readSetting("summary")
   local percent_finished = doc_settings:readSetting("percent_finished")
 
   local book_metadata = {
@@ -216,7 +215,7 @@ function KoInsightAnnotationReader.getBookDataFromSidecar(file_path)
     pages = total_pages or 0,
     highlights = (stats and stats.highlights) or 0,
     notes = (stats and stats.notes) or 0,
-    last_open = os.time(),
+    last_open = 0, -- not available from sidecar; statistics sync sets this correctly
   }
 
   return md5, annotations, total_pages, book_metadata

--- a/plugins/koinsight.koplugin/db_reader.lua
+++ b/plugins/koinsight.koplugin/db_reader.lua
@@ -114,8 +114,12 @@ local function flush_statistics_to_db()
   if not ok or not ReaderUI or not ReaderUI.instance then return end
   local ui = ReaderUI.instance
   if ui and ui.statistics and ui.statistics.is_doc then
-    pcall(function() ui.statistics:insertDB() end)
-    logger.info("[KoInsight] Flushed statistics to DB before sync")
+    local ok_flush, err = pcall(function() ui.statistics:insertDB() end)
+    if ok_flush then
+      logger.info("[KoInsight] Flushed statistics to DB before sync")
+    else
+      logger.warn("[KoInsight] Failed to flush statistics to DB: " .. tostring(err))
+    end
   end
 end
 

--- a/plugins/koinsight.koplugin/db_reader.lua
+++ b/plugins/koinsight.koplugin/db_reader.lua
@@ -109,7 +109,18 @@ function get_md5_by_id(books, target_id)
   return nil
 end
 
+local function flush_statistics_to_db()
+  local ok, ReaderUI = pcall(require, "apps/reader/readerui")
+  if not ok or not ReaderUI or not ReaderUI.instance then return end
+  local ui = ReaderUI.instance
+  if ui and ui.statistics and ui.statistics.is_doc then
+    pcall(function() ui.statistics:insertDB() end)
+    logger.info("[KoInsight] Flushed statistics to DB before sync")
+  end
+end
+
 function KoInsightDbReader.progressData()
+  flush_statistics_to_db()
   local conn = SQ3.open(db_location)
   local result, rows = conn:exec("SELECT * FROM page_stat_data")
   local results = {}


### PR DESCRIPTION
Fix last_open corruption, data loss, and edge case crashes

## Problems

### Main bugs

Several bugs were causing incorrect or missing data after syncing:

- "56 years ago" last open date: the annotation sync path read summary.modified (an ISO date string like "2024-11-30") as the last_open timestamp. SQLite coerced it to 0, making every book appear last opened at Unix epoch (1970)
- Last open date on bulk sync: after fixing the above, os.time() was used as a fallback — but the sidecar contains no reliable last-open timestamp at all. This caused every bulk-synced book to be stamped with the sync time instead of the actual last open date
- Silent data loss on manual sync: KoReader buffers reading session stats in memory and only flushes to disk every ~50 page turns. Triggering a sync mid-session meant the current session's data was never captured. Sync-on-suspend was unaffected because the suspend event chain flushed to statistics.sqlite3 beforehand

### Captured along the way

- In valid page stats reaching the DB: no server-side validation on duration or total_pages fields, allowing null/NaN/zero values to be inserted
- Server error on annotation-only sync: the plugin sends stats = {} (empty Lua table → JSON object {}) on the annotation-only path (simplest option is sending one data strucutre server-side). Calling .filter() on a plain object threw TypeError, returning HTTP 500
- "NaN" avg. daily reading time: possible division by zero on the book detail page when a book had no recorded reading days yet.
- Infinity started-reading date: getStartedReading() returned Infinity for books with no page stats, which could propagate to the client

## Solutions

- Plugin: Set last_open = 0 in the annotation sync path. The sidecar file contains no reliable last-open timestamp, and the statistics sync path already sets this correctly. The server-side guard skips merging zero values, so this is safe.
- Plugin: call ReaderStatistics:insertDB() before reading statistics.sqlite3, ensuring the current in-memory session is flushed first.
- Server: normalize the stats payload to an empty array if it is not an array, guarding against the plugin sending {} on the annotation-only path
- Server: 0nly merge last_open into the DB if it is a valid positive finite number
- Server: filter out page stat rows with invalid/zero duration or total_pages before inserting
- Server: return 0 from getStartedReading() when the stats array is empty instead of Infinity
- Frontend: guard avgPerDay calculation against division by zero when no reading days exist