### PR TITLE
feat(web): add toggle to hide sub-minute calendar entries

### DIFF
--- a/apps/server/src/db/seeds/08_short_sessions.ts
+++ b/apps/server/src/db/seeds/08_short_sessions.ts
@@ -1,0 +1,45 @@
+import { PageStat } from '@koinsight/common/types/page-stat';
+import { setHours, setMinutes, setSeconds, startOfDay, subDays } from 'date-fns';
+import { Knex } from 'knex';
+import { db } from '../../knex';
+import { createPageStat } from '../factories/page-stat-factory';
+import { SEEDED_DEVICES } from './01_devices';
+import { SEEDED_BOOKS } from './02_books';
+import { SEEDED_BOOK_DEVICES } from './03_book_devices';
+
+// Simulates "accidental opens" in KOReader: a book is opened briefly and
+// shows up on the calendar with a 00:00 total. Lets us exercise the
+// "Hide entries under a minute" toggle on the calendar views.
+export async function seed(_knex: Knex): Promise<void> {
+  const today = new Date();
+  const promises: Promise<PageStat>[] = [];
+
+  const targetBooks = SEEDED_BOOKS.slice(0, 6);
+
+  targetBooks.forEach((book, bookIndex) => {
+    const bookDevice = SEEDED_BOOK_DEVICES.find((bd) => bd.book_md5 === book.md5);
+    const device = SEEDED_DEVICES.find((d) => d.id === bookDevice?.device_id);
+    if (!bookDevice || !device) return;
+
+    // Spread short sessions across the last 14 days, one per book per day,
+    // so multiple short entries appear on the same days too.
+    for (let dayOffset = 1; dayOffset <= 14; dayOffset++) {
+      if ((dayOffset + bookIndex) % 3 !== 0) continue;
+
+      const day = subDays(startOfDay(today), dayOffset);
+      const startTime = setSeconds(setMinutes(setHours(day, 9 + bookIndex), 15), 0);
+
+      promises.push(
+        createPageStat(db, book, bookDevice, device, {
+          page: 1,
+          start_time: startTime.valueOf() / 1000,
+          duration: 5 + ((dayOffset + bookIndex) % 20), // 5-24 seconds
+          total_pages: bookDevice.pages,
+        })
+      );
+    }
+  });
+
+  const stats = await Promise.all(promises);
+  console.log(`✓ Seeded ${stats.length} short (under a minute) reading sessions`);
+}

--- a/apps/web/src/pages/book-page/book-page-calendar.tsx
+++ b/apps/web/src/pages/book-page/book-page-calendar.tsx
@@ -1,8 +1,9 @@
 import { BookWithData, PageStat } from '@koinsight/common/types';
+import { Flex, Switch } from '@mantine/core';
 import { IconClock } from '@tabler/icons-react';
 import { startOfDay } from 'date-fns/startOfDay';
 import { sum } from 'ramda';
-import { JSX } from 'react';
+import { JSX, useMemo, useState } from 'react';
 import { Calendar, CalendarEvent } from '../../components/calendar/calendar';
 import { getDuration, shortDuration } from '../../utils/dates';
 
@@ -15,26 +16,54 @@ type DayData = {
 };
 
 export function BookPageCalendar({ book }: BookPageCalendarProps): JSX.Element {
-  const calendarEvents = book.stats.reduce<Record<string, CalendarEvent<DayData>>>((acc, event) => {
-    const date = startOfDay(event.start_time);
-    const key = date.toISOString();
-    acc[key] = acc[key] || { date, data: { events: [] } };
-    acc[key].data = acc[key]?.data?.events
-      ? { events: [...acc[key].data.events, event] }
-      : { events: [event] };
+  const [hideEmpty, setHideEmpty] = useState(false);
 
-    return acc;
-  }, {});
+  const calendarEvents = useMemo(() => {
+    const grouped = book.stats.reduce<Record<string, CalendarEvent<DayData>>>((acc, event) => {
+      const date = startOfDay(event.start_time);
+      const key = date.toISOString();
+      acc[key] = acc[key] || { date, data: { events: [] } };
+      acc[key].data = acc[key]?.data?.events
+        ? { events: [...acc[key].data.events, event] }
+        : { events: [event] };
+
+      return acc;
+    }, {});
+
+    if (!hideEmpty) {
+      return grouped;
+    }
+
+    return Object.entries(grouped).reduce<Record<string, CalendarEvent<DayData>>>(
+      (acc, [key, entry]) => {
+        const total = sum(entry.data!.events.map((event) => event.duration));
+        if (total >= 60) {
+          acc[key] = entry;
+        }
+        return acc;
+      },
+      {}
+    );
+  }, [book.stats, hideEmpty]);
 
   return (
-    <Calendar<DayData>
-      events={calendarEvents}
-      dayRenderer={(data) => (
-        <>
-          <IconClock size={14} />{' '}
-          {shortDuration(getDuration(sum(data.events.map((event) => event.duration))))}
-        </>
-      )}
-    />
+    <>
+      <Flex justify="flex-end" mb="sm">
+        <Switch
+          label="Hide entries under a minute"
+          checked={hideEmpty}
+          onChange={(e) => setHideEmpty(e.currentTarget.checked)}
+        />
+      </Flex>
+      <Calendar<DayData>
+        events={calendarEvents}
+        dayRenderer={(data) => (
+          <>
+            <IconClock size={14} />{' '}
+            {shortDuration(getDuration(sum(data.events.map((event) => event.duration))))}
+          </>
+        )}
+      />
+    </>
   );
 }

--- a/apps/web/src/pages/calendar-page.tsx
+++ b/apps/web/src/pages/calendar-page.tsx
@@ -1,10 +1,10 @@
 import { PageStat } from '@koinsight/common/types';
 import { Book } from '@koinsight/common/types/book';
-import { Anchor, Flex, Loader, Title } from '@mantine/core';
+import { Anchor, Flex, Loader, Switch, Title } from '@mantine/core';
 import { IconClock } from '@tabler/icons-react';
 import { startOfDay } from 'date-fns/startOfDay';
 import { sum, uniq } from 'ramda';
-import { JSX, useCallback, useMemo } from 'react';
+import { JSX, useCallback, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { useBooks } from '../api/books';
 import { usePageStats } from '../api/use-page-stats';
@@ -22,6 +22,8 @@ export function CalendarPage(): JSX.Element {
     data: { stats: events },
     isLoading: eventsLoading,
   } = usePageStats();
+
+  const [hideEmpty, setHideEmpty] = useState(false);
 
   const calendarEvents = useMemo<Record<string, CalendarEvent<DayData>>>(() => {
     if (eventsLoading || !events) {
@@ -42,8 +44,31 @@ export function CalendarPage(): JSX.Element {
       return acc;
     }, {});
 
-    return eventsList;
-  }, [events, eventsLoading]);
+    if (!hideEmpty) {
+      return eventsList;
+    }
+
+    return Object.entries(eventsList).reduce<Record<string, CalendarEvent<DayData>>>(
+      (acc, [key, entry]) => {
+        const totalsByBook = entry.data!.events.reduce<Record<string, number>>((totals, event) => {
+          totals[event.book_md5] = (totals[event.book_md5] ?? 0) + event.duration;
+          return totals;
+        }, {});
+
+        const filtered = entry.data!.events.filter(
+          (event) => totalsByBook[event.book_md5] >= 60
+        );
+
+        if (filtered.length === 0) {
+          return acc;
+        }
+
+        acc[key] = { ...entry, data: { events: filtered } };
+        return acc;
+      },
+      {}
+    );
+  }, [events, eventsLoading, hideEmpty]);
 
   const getBookByMd5 = useCallback(
     (md5: Book['md5']) => books?.find((book) => book.md5 === md5),
@@ -88,7 +113,14 @@ export function CalendarPage(): JSX.Element {
 
   return (
     <>
-      <Title mb="xl">Calendar</Title>
+      <Flex justify="space-between" align="center" mb="xl" wrap="wrap" gap="md">
+        <Title>Calendar</Title>
+        <Switch
+          label="Hide entries under a minute"
+          checked={hideEmpty}
+          onChange={(e) => setHideEmpty(e.currentTarget.checked)}
+        />
+      </Flex>
       <Calendar<DayData>
         events={calendarEvents}
         dayRenderer={(data) => getBookNames(data).map((el) => <div>{el}</div>)}


### PR DESCRIPTION
## Summary

KOReader occasionally records brief, accidental book opens. Those sessions surface on the KoInsight calendar as `00:00` entries (less than a minute of total reading time on that day), which clutters the month view, especially when the same day already has real reading activity on other books.

This PR adds an opt-in **"Hide entries under a minute"** toggle to both calendar views so those incidental opens can be filtered out without removing real data.

## Changes

- **`apps/web/src/pages/calendar-page.tsx`**
  - New `Switch` next to the page title.
  - When enabled, filters out per-book entries whose total daily duration is `< 60s`. Days that end up with no remaining books are dropped from the calendar entirely.
  - State is local to the page and defaults to off.
- **`apps/web/src/pages/book-page/book-page-calendar.tsx`**
  - Same `Switch` placed above the per-book calendar.
  - When enabled, hides days where the book's total reading time is `< 60s`.
- **`apps/server/src/db/seeds/08_short_sessions.ts`** (new)
  - Seeds 28 short (`5-24s`) "accidental open" page stats across the last 14 days for the first 6 books, so the new toggle has data to filter against during local development.

## Rationale

Filtering happens client-side on the already-fetched stats, so there is no API or schema impact. Threshold (60s) matches the existing `shortDuration` formatter, which renders anything below a minute as `00:00`, the exact rows users want to hide.

## Screenshots

- Before: calendar shows every accidental open as a `00:00` line under the day.
<img width="1632" height="1287" alt="Screenshot 2026-04-29 at 10 13 36 AM" src="https://github.com/user-attachments/assets/154084a5-26ef-47a5-bf08-be99174aada4" />

- After (toggle on): days collapse to only the books with at least a minute of reading; days with nothing else disappear.
<img width="1632" height="1287" alt="Screenshot 2026-04-29 at 10 13 43 AM" src="https://github.com/user-attachments/assets/916f2b6a-667b-42ca-944c-c0fc8a6e78b1" />


## Test plan

- [ ] `npm run seed` (in `apps/server/`) repopulates the dev DB, including the new short sessions.
- [ ] Navigate to `/calendar`, confirm `00:00` entries are visible by default.
- [ ] Flip "Hide entries under a minute" — sub-minute book entries disappear; days with only such entries collapse.
- [ ] Open any book detail page, repeat the same check on the per-book calendar.
- [ ] Toggle off; entries reappear.

## Notes for reviewers

- Seed file is independent of the toggle logic; happy to drop it from the PR if seed changes should land separately.
- No new dependencies. Uses existing Mantine `Switch` and `ramda.sum`.
