### PR TITLE
Catching and reseting IsLoading if cover search fails

### DIFF
--- a/apps/web/src/pages/book-page/components/book-page-cover-selector.tsx
+++ b/apps/web/src/pages/book-page/components/book-page-cover-selector.tsx
@@ -42,8 +42,18 @@ export function BookPageCoverSelector({
       loadedCovers: [],
       isSavingCovers: false,
     }));
-    const coverIds = await listCovers(state.query || book.title);
-    setState((prev) => ({ ...prev, isLoading: false, data: coverIds }));
+    try {
+      const coverIds = await listCovers(state.query || book.title);
+      setState((prev) => ({ ...prev, isLoading: false, data: coverIds }));
+    } catch (error) {
+      setState((prev) => ({ ...prev, isLoading: false, data: [] }));
+      notifications.show({
+        title: 'Error fetching covers',
+        message: `Unable to fetch covers for ${book.title}.`,
+        color: 'red',
+        position: 'top-center',
+      });
+    }
   };
 
   const onSave = async (coverId: string) => {


### PR DESCRIPTION
Failures from the open-library cover search left the search button in a loading state.  

Catching that error, resetting IsLoading and displaying a generic error

<img width="972" height="535" alt="image" src="https://github.com/user-attachments/assets/7db94284-34b3-4c5d-a009-381af6fbd72c" />
