### PR TITLE
Add URL validation to settings window

### DIFF
--- a/plugins/koinsight.koplugin/settings.lua
+++ b/plugins/koinsight.koplugin/settings.lua
@@ -218,29 +218,29 @@ function KoInsightSettings:editServerSettings()
         {
           text = _("Apply"),
           callback = function()
-              local myfields = self.settings_dialog:getFields()
-              local server_url = myfields[1]
+            local myfields = self.settings_dialog:getFields()
+            local server_url = myfields[1]
 
-              if server_url == "" then
-                  UIManager:show(InfoMessage:new({
-                      text = _("Please enter a server URL."),
-                  }))
-                  return
-              end
+            if server_url == "" then
+                UIManager:show(InfoMessage:new({
+                    text = _("Please enter a server URL."),
+                }))
+                return
+            end
 
-              if not server_url:match("^https?://") then
-                  UIManager:show(InfoMessage:new({
-                      text = _("The server URL must start with 'http://' or 'https://'.\n\n"),
-                  }))
-                  return
-              end
+            if not server_url:match("^https?://") then
+                UIManager:show(InfoMessage:new({
+                    text = _("The server URL must start with 'http://' or 'https://'.\n\n"),
+                }))
+                return
+            end
 
-              self:setServerURL(server_url)
-              UIManager:close(self.settings_dialog)
-              UIManager:show(InfoMessage:new({
-                  text = _("KoInsight settings saved."),
-                  timeout = 2,
-              }))
+            self:setServerURL(server_url)
+            UIManager:close(self.settings_dialog)
+            UIManager:show(InfoMessage:new({
+                text = _("KoInsight settings saved."),
+                timeout = 2,
+            }))
           end,
         },
       },

--- a/plugins/koinsight.koplugin/settings.lua
+++ b/plugins/koinsight.koplugin/settings.lua
@@ -218,10 +218,29 @@ function KoInsightSettings:editServerSettings()
         {
           text = _("Apply"),
           callback = function()
-            local myfields = self.settings_dialog:getFields()
-            self:setServerURL(myfields[1])
-            UIManager:close(self.settings_dialog)
-            UIManager:show(InfoMessage:new({ text = _("KoInsight settings saved."), timeout = 2 }))
+              local myfields = self.settings_dialog:getFields()
+              local server_url = myfields[1]
+
+              if server_url == "" then
+                  UIManager:show(InfoMessage:new({
+                      text = _("Please enter a server URL."),
+                  }))
+                  return
+              end
+
+              if not server_url:match("^https?://") then
+                  UIManager:show(InfoMessage:new({
+                      text = _("The server URL must start with 'http://' or 'https://'.\n\n"),
+                  }))
+                  return
+              end
+
+              self:setServerURL(server_url)
+              UIManager:close(self.settings_dialog)
+              UIManager:show(InfoMessage:new({
+                  text = _("KoInsight settings saved."),
+                  timeout = 2,
+              }))
           end,
         },
       },


### PR DESCRIPTION
I previously opened an issue (https://github.com/Ko-Insight/KoInsight/issues/102) because I could not get KoInsight to sync from my Kobo. After digging a bit deeper I figured out I was being dumb and forgot to add "http://" to my server URL. To prevent others from repeating this I have now added a simple check directly in the settings window that checks whether the URL starts with "http://" or "https://".